### PR TITLE
Prevented KeyError on signal restoration

### DIFF
--- a/pgnotify/notify.py
+++ b/pgnotify/notify.py
@@ -160,6 +160,7 @@ def await_pg_notifications(
     finally:
         if signals_to_handle:
             for s in signals_to_handle:
-                signal_name = signal.Signals(s).name
-                log.debug(f"restoring original handler for: {signal_name}")
-                signal.signal(s, original_handlers[s])
+                if s in original_handlers:
+                    signal_name = signal.Signals(s).name
+                    log.debug(f"restoring original handler for: {signal_name}")
+                    signal.signal(s, original_handlers[s])


### PR DESCRIPTION
If the original_handlers dictionary is not yet populated before an error
is encountered in the main try section of await_pg_notifications(), the
"finally" section may encounter a KeyError when attempting to cleanup. I
encountered this by an early failure in the function due to some illegal
asynchonous behavior.